### PR TITLE
Enhance flake8-vedro-allure with allure.id() requirement and testing 

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,7 +25,6 @@ jobs:
         
   publish_pypi:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -34,7 +33,9 @@ jobs:
       with:
         python-version: "3.10"
     - name: Install
-      run: pip3 install --quiet --upgrade setuptools wheel twine
+      run: |
+        pip3 install --quiet --upgrade setuptools pytest
+        pip3 install -e .
     - name: Test
       run: python3 -m pytest tests/
     - name: Build

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,6 +6,23 @@ on:
       - "v*.*.*"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    push:
+      branches:
+        - '*'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install
+        run: pip3 install --quiet --upgrade setuptools wheel twine
+      - name: Test
+        run: python3 -m pytest tests/
+        
   publish_pypi:
     runs-on: ubuntu-latest
 
@@ -18,6 +35,8 @@ jobs:
         python-version: "3.10"
     - name: Install
       run: pip3 install --quiet --upgrade setuptools wheel twine
+    - name: Test
+      run: python3 -m pytest tests/
     - name: Build
       run: python3 setup.py sdist bdist_wheel
     - name: Publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install
+        run: |
+          pip3 install --quiet --upgrade setuptools pytest
+          pip3 install -e .
+      - name: Test
+        run: python3 -m pytest tests/ 

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ lint:
 .PHONY: fix-imports
 fix-imports:
 	python3 -m isort -m VERTICAL_HANGING_INDENT .
+
+.PHONY: test
+test:
+	python3 -m pytest tests/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flake8 based linter for Vedro framework and allure
 ## Installation
 
 ```bash
-pip inslall flake8-vedro-allure
+pip install flake8-vedro-allure
 ```
 
 
@@ -13,6 +13,7 @@ pip inslall flake8-vedro-allure
 1. **ALR001**: missing @allure_labels for scenario
 2. **ALR002**: missing required allure tag
 3. **ALR003**: duplication of unique allure tag
+4. **ALR004**: missing allure.id() for scenario
 
 **Rules configuration**
 ```editorconfig
@@ -20,6 +21,25 @@ pip inslall flake8-vedro-allure
 is_allure_labels_optional = false                 ;ALR001
 required_allure_labels = Feature,Story,Priority   ;ALR002
 unique_allure_labels = Priority                   ;ALR003
+is_allure_id_required = false                     ;ALR004
+```
+
+### About ALR004 (allure.id)
+The ALR004 rule checks that all scenarios have an Allure ID. This can be defined in two ways:
+
+1. Using the `@allure.id()` decorator on the scenario class:
+```python
+@allure.id(12345)
+class MyScenario(Scenario):
+    # ...
+```
+
+2. Within a method in the scenario class:
+```python
+class MyScenario(Scenario):
+    def __init__(self):
+        allure.id(12345)  # or allure.dynamic.id(12345)
+        # ...
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ pip install flake8-vedro-allure
 2. **ALR002**: missing required allure tag
 3. **ALR003**: duplication of unique allure tag
 4. **ALR004**: missing allure.id() for scenario
+5. **ALR005**: duplicate allure id detected in another scenario
 
 **Rules configuration**
 ```editorconfig
@@ -21,7 +22,7 @@ pip install flake8-vedro-allure
 is_allure_labels_optional = false                 ;ALR001
 required_allure_labels = Feature,Story,Priority   ;ALR002
 unique_allure_labels = Priority                   ;ALR003
-is_allure_id_required = false                     ;ALR004
+is_allure_id_required = false                     ;ALR004, ALR005
 ```
 
 ### About ALR004 (allure.id)
@@ -41,6 +42,49 @@ class MyScenario(Scenario):
         allure.id(12345)  # or allure.dynamic.id(12345)
         # ...
 ```
+
+### About ALR005 (duplicate allure id)
+The ALR005 rule checks that each scenario has a unique Allure ID. The rule will report an error if the same ID is used in multiple scenarios. The duplicate detection works across different files and can identify duplicates between different classes within the same file.
+
+This rule uses the same configuration parameter as ALR004 (`is_allure_id_required = true`). When enabled, it will:
+
+1. Detect duplicates in class decorators:
+```python
+@allure.id(12345)  # First usage is OK
+class FirstScenario(Scenario):
+    # ...
+
+@allure.id(12345)  # Error: duplicate allure id 12345 was found in file1.py::FirstScenario
+class SecondScenario(Scenario):
+    # ...
+```
+
+2. Detect duplicates in method calls:
+```python
+class FirstScenario(Scenario):
+    def __init__(self):
+        allure.id(12345)  # First usage is OK
+        # ...
+
+class SecondScenario(Scenario):
+    def __init__(self):
+        allure.id(12345)  # Error: duplicate allure id 12345 was found in file1.py::FirstScenario
+        # ...
+```
+
+3. Detect duplicates between decorator and method calls:
+```python
+@allure.id(12345)  # First usage is OK
+class FirstScenario(Scenario):
+    # ...
+
+class SecondScenario(Scenario):
+    def __init__(self):
+        allure.id(12345)  # Error: duplicate allure id 12345 was found in file1.py::FirstScenario
+        # ...
+```
+
+The rule helps ensure that each scenario has a unique identifier in Allure reports, which is important for tracking test cases and their results.
 
 ## Configuration
 Flake8-vedro-allure is flake8 plugin, so the configuration is the same as [flake8 configuration](https://flake8.pycqa.org/en/latest/user/configuration.html).

--- a/README.md
+++ b/README.md
@@ -26,21 +26,31 @@ is_allure_id_required = false                     ;ALR004, ALR005
 ```
 
 ### About ALR004 (allure.id)
-The ALR004 rule checks that all scenarios have an Allure ID. This can be defined in two ways:
+The ALR004 rule checks that all scenarios have an Allure ID. This can be defined in several ways:
 
 1. Using the `@allure.id()` decorator on the scenario class:
 ```python
+import allure
+
 @allure.id(12345)
 class MyScenario(Scenario):
     # ...
 ```
 
-2. Within a method in the scenario class:
+2. Using a direct import:
+```python
+from allure import id
+
+@id(12345)
+class MyScenario(Scenario):
+    # ...
+```
+
+3. Within `__init__` for parameterized scenarios:
 ```python
 class MyScenario(Scenario):
-    def __init__(self):
-        allure.id(12345)  # or allure.dynamic.id(12345)
-        # ...
+    def __init__(self, param, allure_id):
+        allure.id(allure_id)  # or allure.dynamic.id(allure_id)
 ```
 
 ### About ALR005 (duplicate allure id)

--- a/flake8_vedro_allure/abstract_checkers/scenario_helper.py
+++ b/flake8_vedro_allure/abstract_checkers/scenario_helper.py
@@ -1,16 +1,65 @@
 import ast
-from typing import List, Union
+from typing import List, Union, Optional
 
 SCENARIOS_FOLDER = 'scenarios'
 
 
 class ScenarioHelper:
 
-    def get_allure_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
+    def get_decorator_by_name_or_attr(
+        self, 
+        scenario_node: ast.ClassDef,
+        name: Optional[str] = None,
+        attr: Optional[str] = None,
+        parent_name: Optional[str] = None
+    ) -> Union[ast.Call, None]:
+        """
+        Ищет декоратор по имени или атрибуту.
+        
+        Args:
+            scenario_node: Узел класса сценария
+            name: Имя декоратора (для простых декораторов)
+            attr: Имя атрибута (для декораторов вида parent.attr)
+            parent_name: Имя родительского объекта (для декораторов вида parent.attr)
+            
+        Returns:
+            Найденный декоратор или None
+        """
         for decorator in scenario_node.decorator_list:
-            if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name):
-                if decorator.func.id == 'allure_labels':
+            if not isinstance(decorator, ast.Call):
+                continue
+                
+            if name is not None:
+                if isinstance(decorator.func, ast.Name) and decorator.func.id == name:
                     return decorator
+                    
+            if attr is not None:
+                if parent_name is not None:
+                    if (isinstance(decorator.func, ast.Attribute) and 
+                        decorator.func.attr == attr and 
+                        isinstance(decorator.func.value, ast.Name) and 
+                        decorator.func.value.id == parent_name):
+                        return decorator
+                else:
+                    if isinstance(decorator.func, ast.Name) and decorator.func.id == attr:
+                        return decorator
+                    
+        return None
+
+    def get_allure_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
+        return self.get_decorator_by_name_or_attr(scenario_node, name='allure_labels')
+
+    def get_allure_id_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
+        return (
+            self.get_decorator_by_name_or_attr(
+                scenario_node,
+                attr='id',
+                parent_name='allure'
+            ) or self.get_decorator_by_name_or_attr(
+                scenario_node,
+                name='id'
+            )
+        )
 
     def get_allure_tag_names(self, allure_decorator: ast.Call) -> List[str]:
 
@@ -19,6 +68,7 @@ class ScenarioHelper:
                 return get_tag_first_name(arg.value)
             if isinstance(arg.value, ast.Name):
                 return arg.value.id
+            return arg.attr  # Возвращаем имя атрибута как запасной вариант
 
         tags_names = []
         for arg in allure_decorator.args:

--- a/flake8_vedro_allure/abstract_checkers/scenario_helper.py
+++ b/flake8_vedro_allure/abstract_checkers/scenario_helper.py
@@ -7,59 +7,65 @@ SCENARIOS_FOLDER = 'scenarios'
 class ScenarioHelper:
 
     def get_decorator_by_name_or_attr(
-        self, 
+        self,
         scenario_node: ast.ClassDef,
         name: Optional[str] = None,
         attr: Optional[str] = None,
         parent_name: Optional[str] = None
     ) -> Union[ast.Call, None]:
-        """
-        Ищет декоратор по имени или атрибуту.
-        
-        Args:
-            scenario_node: Узел класса сценария
-            name: Имя декоратора (для простых декораторов)
-            attr: Имя атрибута (для декораторов вида parent.attr)
-            parent_name: Имя родительского объекта (для декораторов вида parent.attr)
-            
-        Returns:
-            Найденный декоратор или None
-        """
         for decorator in scenario_node.decorator_list:
             if not isinstance(decorator, ast.Call):
                 continue
-                
+
             if name is not None:
                 if isinstance(decorator.func, ast.Name) and decorator.func.id == name:
                     return decorator
-                    
+
             if attr is not None:
                 if parent_name is not None:
-                    if (isinstance(decorator.func, ast.Attribute) and 
-                        decorator.func.attr == attr and 
-                        isinstance(decorator.func.value, ast.Name) and 
+                    if (isinstance(decorator.func, ast.Attribute) and
+                        decorator.func.attr == attr and
+                        isinstance(decorator.func.value, ast.Name) and
                         decorator.func.value.id == parent_name):
                         return decorator
                 else:
                     if isinstance(decorator.func, ast.Name) and decorator.func.id == attr:
                         return decorator
-                    
+
         return None
 
     def get_allure_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
         return self.get_decorator_by_name_or_attr(scenario_node, name='allure_labels')
 
-    def get_allure_id_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
-        return (
-            self.get_decorator_by_name_or_attr(
-                scenario_node,
-                attr='id',
-                parent_name='allure'
-            ) or self.get_decorator_by_name_or_attr(
-                scenario_node,
-                name='id'
-            )
+    def _is_id_imported_from_allure(self, import_from_nodes: List[ast.ImportFrom]) -> bool:
+        for import_from in import_from_nodes:
+            if import_from.module == 'allure':
+                for name in import_from.names:
+                    if name.name == 'id':
+                        return True
+        return False
+
+    def get_allure_id_decorator(
+        self,
+        scenario_node: ast.ClassDef,
+        import_from_nodes: Optional[List[ast.ImportFrom]] = None
+    ) -> Union[ast.Call, None]:
+        allure_id = self.get_decorator_by_name_or_attr(
+            scenario_node,
+            attr='id',
+            parent_name='allure'
         )
+        if allure_id:
+            return allure_id
+
+        id_decorator = self.get_decorator_by_name_or_attr(
+            scenario_node,
+            name='id'
+        )
+        if id_decorator and import_from_nodes and self._is_id_imported_from_allure(import_from_nodes):
+            return id_decorator
+
+        return None
 
     def get_allure_tag_names(self, allure_decorator: ast.Call) -> List[str]:
 
@@ -68,7 +74,7 @@ class ScenarioHelper:
                 return get_tag_first_name(arg.value)
             if isinstance(arg.value, ast.Name):
                 return arg.value.id
-            return arg.attr  # Возвращаем имя атрибута как запасной вариант
+            return arg.attr
 
         tags_names = []
         for arg in allure_decorator.args:

--- a/flake8_vedro_allure/config.py
+++ b/flake8_vedro_allure/config.py
@@ -6,11 +6,13 @@ class Config:
             self,
             is_allure_labels_optional: bool,
             required_allure_labels: Optional[List],
-            unique_allure_labels: Optional[List]
+            unique_allure_labels: Optional[List],
+            is_allure_id_required: bool = False
     ):
         self.is_allure_labels_optional = is_allure_labels_optional
         self.required_allure_labels = required_allure_labels if required_allure_labels else []
         self.unique_allure_labels = unique_allure_labels if unique_allure_labels else []
+        self.is_allure_id_required = is_allure_id_required
 
 
 class DefaultConfig(Config):
@@ -18,11 +20,13 @@ class DefaultConfig(Config):
             self,
             is_allure_labels_optional: bool = True,
             required_allure_labels: Optional[List] = None,
-            unique_allure_labels: Optional[List] = None
+            unique_allure_labels: Optional[List] = None,
+            is_allure_id_required: bool = False
     ):
 
         super().__init__(
             is_allure_labels_optional=is_allure_labels_optional,
             required_allure_labels=required_allure_labels,
-            unique_allure_labels=unique_allure_labels
+            unique_allure_labels=unique_allure_labels,
+            is_allure_id_required=is_allure_id_required
         )

--- a/flake8_vedro_allure/errors/__init__.py
+++ b/flake8_vedro_allure/errors/__init__.py
@@ -1,5 +1,6 @@
 from .errors import (
     AllureTagIsNotUnique,
     NoAllureLabelsDecorator,
-    NoRequiredAllureTag
+    NoRequiredAllureTag,
+    NoAllureIdError
 )

--- a/flake8_vedro_allure/errors/__init__.py
+++ b/flake8_vedro_allure/errors/__init__.py
@@ -2,5 +2,6 @@ from .errors import (
     AllureTagIsNotUnique,
     NoAllureLabelsDecorator,
     NoRequiredAllureTag,
-    NoAllureIdError
+    NoAllureIdError,
+    DuplicateAllureIdError
 )

--- a/flake8_vedro_allure/errors/errors.py
+++ b/flake8_vedro_allure/errors/errors.py
@@ -14,3 +14,8 @@ class NoRequiredAllureTag(Error):
 class AllureTagIsNotUnique(Error):
     code = 'ALR003'
     message = 'scenario should has only one allure tag {allure_tag}'
+
+
+class NoAllureIdError(Error):
+    code = 'ALR004'
+    message = 'scenario should have @allure.id() decorator'

--- a/flake8_vedro_allure/errors/errors.py
+++ b/flake8_vedro_allure/errors/errors.py
@@ -18,4 +18,4 @@ class AllureTagIsNotUnique(Error):
 
 class NoAllureIdError(Error):
     code = 'ALR004'
-    message = 'scenario should have @allure.id() decorator'
+    message = 'scenario should have @allure.id() or @id() decorator'

--- a/flake8_vedro_allure/errors/errors.py
+++ b/flake8_vedro_allure/errors/errors.py
@@ -19,3 +19,15 @@ class AllureTagIsNotUnique(Error):
 class NoAllureIdError(Error):
     code = 'ALR004'
     message = 'scenario should have @allure.id() or @id() decorator'
+
+
+class DuplicateAllureIdError(Error):
+    code = 'ALR005'
+    message = 'duplicate allure id {allure_id} was found in {scenario_path}'
+    
+    def __init__(self, lineno: int, col_offset: int, **kwargs):
+        super().__init__(lineno, col_offset, **kwargs)
+        
+    @classmethod
+    def formatted_message(cls, **kwargs) -> str:
+        return cls.message.format(**kwargs)

--- a/flake8_vedro_allure/errors/errors.py
+++ b/flake8_vedro_allure/errors/errors.py
@@ -18,16 +18,9 @@ class AllureTagIsNotUnique(Error):
 
 class NoAllureIdError(Error):
     code = 'ALR004'
-    message = 'scenario should have @allure.id() or @id() decorator'
+    message = 'scenario should have @allure.id() decorator or allure.id() call'
 
 
 class DuplicateAllureIdError(Error):
     code = 'ALR005'
     message = 'duplicate allure id {allure_id} was found in {scenario_path}'
-    
-    def __init__(self, lineno: int, col_offset: int, **kwargs):
-        super().__init__(lineno, col_offset, **kwargs)
-        
-    @classmethod
-    def formatted_message(cls, **kwargs) -> str:
-        return cls.message.format(**kwargs)

--- a/flake8_vedro_allure/plugins.py
+++ b/flake8_vedro_allure/plugins.py
@@ -64,6 +64,13 @@ class VedroAllurePlugin(PluginWithFilename):
             parse_from_config=True,
             help='List of allure labels that should not be used twice per one test',
         )
+        option_manager.add_option(
+            '--is-allure-id-required',
+            type=str,
+            default='false',
+            parse_from_config=True,
+            help='If allure.id() decorator is required for every test',
+        )
 
 
     @classmethod
@@ -73,5 +80,6 @@ class VedroAllurePlugin(PluginWithFilename):
         return Config(
             is_allure_labels_optional=str_to_bool(options.is_allure_labels_optional),
             required_allure_labels=options.required_allure_labels,
-            unique_allure_labels=options.unique_allure_labels
+            unique_allure_labels=options.unique_allure_labels,
+            is_allure_id_required=str_to_bool(options.is_allure_id_required)
         )

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/__init__.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/__init__.py
@@ -1,4 +1,5 @@
+from .allure_id_checker import AllureIdRequiredChecker
 from .allure_labels_checker import AllureLabelsChecker
 from .required_tags_checker import AllureRequiredTagsChecker
 from .unique_tags_checker import AllureUniqueTagsChecker
-from .allure_id_checker import AllureIdRequiredChecker
+from .duplicate_allure_id_checker import DuplicateAllureIdChecker

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/__init__.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/__init__.py
@@ -1,3 +1,4 @@
 from .allure_labels_checker import AllureLabelsChecker
 from .required_tags_checker import AllureRequiredTagsChecker
 from .unique_tags_checker import AllureUniqueTagsChecker
+from .allure_id_checker import AllureIdRequiredChecker

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
@@ -15,13 +15,6 @@ from flake8_vedro_allure.visitors.scenario_visitor import (
 @ScenarioVisitor.register_scenario_checker
 class AllureIdRequiredChecker(ScenarioChecker):
 
-    def get_allure_id_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
-        for decorator in scenario_node.decorator_list:
-            if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Attribute):
-                if decorator.func.attr == 'id' and isinstance(decorator.func.value, ast.Name) and decorator.func.value.id == 'allure':
-                    return decorator
-        return None
-
     def has_allure_id_method(self, scenario_node: ast.ClassDef) -> bool:
         for node in scenario_node.body:
             if isinstance(node, ast.FunctionDef):

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
@@ -1,0 +1,59 @@
+import ast
+from typing import List, Union
+
+from flake8_plugin_utils import Error
+
+from flake8_vedro_allure.abstract_checkers import ScenarioChecker
+from flake8_vedro_allure.config import Config
+from flake8_vedro_allure.errors import NoAllureIdError
+from flake8_vedro_allure.visitors.scenario_visitor import (
+    Context,
+    ScenarioVisitor
+)
+
+
+@ScenarioVisitor.register_scenario_checker
+class AllureIdRequiredChecker(ScenarioChecker):
+
+    def get_allure_id_decorator(self, scenario_node: ast.ClassDef) -> Union[ast.Call, None]:
+        for decorator in scenario_node.decorator_list:
+            if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Attribute):
+                if decorator.func.attr == 'id' and isinstance(decorator.func.value, ast.Name) and decorator.func.value.id == 'allure':
+                    return decorator
+        return None
+
+    def has_allure_id_method(self, scenario_node: ast.ClassDef) -> bool:
+        for node in scenario_node.body:
+            if isinstance(node, ast.FunctionDef):
+                for stmt in node.body:
+                    if self._is_allure_id_assignment(stmt):
+                        return True
+        return False
+
+    def _is_allure_id_assignment(self, node: ast.stmt) -> bool:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            if isinstance(node.value.func, ast.Attribute):
+                if node.value.func.attr == 'id':
+                    if (isinstance(node.value.func.value, ast.Name) and 
+                        node.value.func.value.id == 'allure'):
+                        return True
+                    elif (isinstance(node.value.func.value, ast.Attribute) and 
+                          node.value.func.value.attr == 'dynamic' and
+                          isinstance(node.value.func.value.value, ast.Name) and
+                          node.value.func.value.value.id == 'allure'):
+                        return True
+        return False
+
+    def check_scenario(self, context: Context, config: Config) -> List[Error]:
+        if not config.is_allure_id_required:
+            return []
+
+        allure_id_decorator = self.get_allure_id_decorator(context.scenario_node)
+        
+        has_allure_id_method = self.has_allure_id_method(context.scenario_node)
+
+        if not allure_id_decorator and not has_allure_id_method:
+            return [NoAllureIdError(context.scenario_node.lineno, 
+                                    context.scenario_node.col_offset)]
+
+        return [] 

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/allure_id_checker.py
@@ -1,5 +1,5 @@
 import ast
-from typing import List, Union
+from typing import List
 
 from flake8_plugin_utils import Error
 
@@ -17,7 +17,7 @@ class AllureIdRequiredChecker(ScenarioChecker):
 
     def has_allure_id_method(self, scenario_node: ast.ClassDef) -> bool:
         for node in scenario_node.body:
-            if isinstance(node, ast.FunctionDef):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 for stmt in node.body:
                     if self._is_allure_id_assignment(stmt):
                         return True
@@ -27,10 +27,10 @@ class AllureIdRequiredChecker(ScenarioChecker):
         if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
             if isinstance(node.value.func, ast.Attribute):
                 if node.value.func.attr == 'id':
-                    if (isinstance(node.value.func.value, ast.Name) and 
+                    if (isinstance(node.value.func.value, ast.Name) and
                         node.value.func.value.id == 'allure'):
                         return True
-                    elif (isinstance(node.value.func.value, ast.Attribute) and 
+                    elif (isinstance(node.value.func.value, ast.Attribute) and
                           node.value.func.value.attr == 'dynamic' and
                           isinstance(node.value.func.value.value, ast.Name) and
                           node.value.func.value.value.id == 'allure'):
@@ -41,12 +41,15 @@ class AllureIdRequiredChecker(ScenarioChecker):
         if not config.is_allure_id_required:
             return []
 
-        allure_id_decorator = self.get_allure_id_decorator(context.scenario_node)
-        
+        allure_id_decorator = self.get_allure_id_decorator(
+            context.scenario_node,
+            context.import_from_nodes
+        )
+
         has_allure_id_method = self.has_allure_id_method(context.scenario_node)
 
         if not allure_id_decorator and not has_allure_id_method:
-            return [NoAllureIdError(context.scenario_node.lineno, 
+            return [NoAllureIdError(context.scenario_node.lineno,
                                     context.scenario_node.col_offset)]
 
-        return [] 
+        return []

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/duplicate_allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/duplicate_allure_id_checker.py
@@ -1,0 +1,75 @@
+import ast
+from typing import List, Dict, Tuple, Optional
+
+from flake8_plugin_utils import Error
+
+from flake8_vedro_allure.abstract_checkers import ScenarioChecker
+from flake8_vedro_allure.config import Config
+from flake8_vedro_allure.errors import DuplicateAllureIdError
+from flake8_vedro_allure.visitors.scenario_visitor import (
+    Context,
+    ScenarioVisitor
+)
+
+
+@ScenarioVisitor.register_scenario_checker
+class DuplicateAllureIdChecker(ScenarioChecker):
+    # Cache for tracking allure ids across different files
+    # Format: allure_id -> (filename, class_name, lineno)
+    _allure_ids: Dict[str, Tuple[str, str, int]] = {}
+
+    def extract_allure_id(self, scenario_node: ast.ClassDef) -> Optional[str]:
+        """
+        Extracts the value of allure.id or id from the scenario decorator
+        
+        Args:
+            scenario_node: The scenario class node
+            
+        Returns:
+            String representation of the allure id or None
+        """
+        allure_id_decorator = self.get_allure_id_decorator(scenario_node)
+        if not allure_id_decorator or not allure_id_decorator.args:
+            return None
+
+        arg = allure_id_decorator.args[0]
+
+        if isinstance(arg, ast.Constant) and arg.value is not None:
+            return str(arg.value)
+        return None
+
+    def check_scenario(self, context: Context, config: Config) -> List[Error]:
+        errors: List[Error] = []
+
+        allure_id = self.extract_allure_id(context.scenario_node)
+
+        if not allure_id or not config.is_allure_id_required:
+            return errors
+
+        filename = context.filename or 'unknown_file.py'
+        class_name = context.scenario_node.name
+
+        if allure_id in self._allure_ids:
+            stored_filename, stored_class, stored_lineno = self._allure_ids[allure_id]
+
+            # consider it a duplicate
+            if stored_filename != filename or stored_class != class_name:
+                errors.append(
+                    DuplicateAllureIdError(
+                        context.scenario_node.lineno,
+                        context.scenario_node.col_offset,
+                        allure_id=allure_id,
+                        scenario_path=f"{stored_filename}::{stored_class}"
+                    )
+                )
+        else:
+            self._allure_ids[allure_id] = (filename, class_name, context.scenario_node.lineno)
+            
+        return errors
+        
+    @classmethod
+    def reset_checker(cls):
+        """
+        Resets the accumulated allure ids for a new check
+        """
+        cls._allure_ids = {} 

--- a/flake8_vedro_allure/visitors/scenario_allure_checkers/duplicate_allure_id_checker.py
+++ b/flake8_vedro_allure/visitors/scenario_allure_checkers/duplicate_allure_id_checker.py
@@ -1,5 +1,5 @@
 import ast
-from typing import List, Dict, Tuple, Optional
+from typing import List, Dict, Optional, NamedTuple
 
 from flake8_plugin_utils import Error
 
@@ -12,64 +12,67 @@ from flake8_vedro_allure.visitors.scenario_visitor import (
 )
 
 
+class AllureIdInScenario(NamedTuple):
+    scenario_path: str
+    lineno: int
+
+
 @ScenarioVisitor.register_scenario_checker
 class DuplicateAllureIdChecker(ScenarioChecker):
-    # Cache for tracking allure ids across different files
-    # Format: allure_id -> (filename, class_name, lineno)
-    _allure_ids: Dict[str, Tuple[str, str, int]] = {}
 
-    def extract_allure_id(self, scenario_node: ast.ClassDef) -> Optional[str]:
-        """
-        Extracts the value of allure.id or id from the scenario decorator
-        
-        Args:
-            scenario_node: The scenario class node
-            
-        Returns:
-            String representation of the allure id or None
-        """
-        allure_id_decorator = self.get_allure_id_decorator(scenario_node)
-        if not allure_id_decorator or not allure_id_decorator.args:
+    def __init__(self):
+        self._allure_ids: Dict[str, AllureIdInScenario] = {}
+
+    def extract_allure_id(self, scenario_node: ast.ClassDef,
+                          import_from_nodes: Optional[List[ast.ImportFrom]] = None) -> Optional[str]:
+        allure_id_decorator = self.get_allure_id_decorator(scenario_node, import_from_nodes)
+        if not allure_id_decorator:
             return None
 
-        arg = allure_id_decorator.args[0]
+        if allure_id_decorator.args:
+            arg = allure_id_decorator.args[0]
+            if isinstance(arg, ast.Constant) and arg.value is not None:
+                return str(arg.value)
 
-        if isinstance(arg, ast.Constant) and arg.value is not None:
-            return str(arg.value)
+        for keyword in allure_id_decorator.keywords:
+            if keyword.arg == 'id':
+                if isinstance(keyword.value, ast.Constant) and keyword.value is not None:
+                    return str(keyword.value.value)
+
         return None
 
     def check_scenario(self, context: Context, config: Config) -> List[Error]:
-        errors: List[Error] = []
+        if not config.is_allure_id_required:
+            return []
 
-        allure_id = self.extract_allure_id(context.scenario_node)
+        allure_id = self.extract_allure_id(
+            context.scenario_node,
+            context.import_from_nodes
+        )
 
-        if not allure_id or not config.is_allure_id_required:
-            return errors
+        if not allure_id:
+            return []
 
         filename = context.filename or 'unknown_file.py'
-        class_name = context.scenario_node.name
 
         if allure_id in self._allure_ids:
-            stored_filename, stored_class, stored_lineno = self._allure_ids[allure_id]
-
-            # consider it a duplicate
-            if stored_filename != filename or stored_class != class_name:
-                errors.append(
+            stored = self._allure_ids[allure_id]
+            if stored.scenario_path != filename:
+                return [
                     DuplicateAllureIdError(
                         context.scenario_node.lineno,
                         context.scenario_node.col_offset,
                         allure_id=allure_id,
-                        scenario_path=f"{stored_filename}::{stored_class}"
+                        scenario_path=stored.scenario_path
                     )
-                )
-        else:
-            self._allure_ids[allure_id] = (filename, class_name, context.scenario_node.lineno)
-            
-        return errors
-        
-    @classmethod
-    def reset_checker(cls):
-        """
-        Resets the accumulated allure ids for a new check
-        """
-        cls._allure_ids = {} 
+                ]
+
+        self._allure_ids[allure_id] = AllureIdInScenario(
+            scenario_path=filename,
+            lineno=context.scenario_node.lineno
+        )
+
+        return []
+
+    def reset_checker(self):
+        self._allure_ids = {}

--- a/flake8_vedro_allure/visitors/scenario_visitor.py
+++ b/flake8_vedro_allure/visitors/scenario_visitor.py
@@ -10,8 +10,10 @@ from flake8_vedro_allure.visitors._visitor_with_filename import (
 
 class Context:
     def __init__(self, scenario_node: ast.ClassDef,
+                 import_from_nodes: List[ast.ImportFrom],
                  filename: str):
         self.scenario_node = scenario_node
+        self.import_from_nodes = import_from_nodes
         self.filename = filename
 
 
@@ -36,9 +38,13 @@ class ScenarioVisitor(VisitorWithFilename):
     def deregister_all(cls):
         cls.scenarios_checkers = []
 
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        self.import_from_nodes.append(node)
+
     def visit_ClassDef(self, node: ast.ClassDef):
         if node.name == 'Scenario':
             context = Context(scenario_node=node,
+                              import_from_nodes=self.import_from_nodes,
                               filename=self.filename)
             try:
                 for checker in self.scenarios_checkers:

--- a/tests/test_allure_id_required.py
+++ b/tests/test_allure_id_required.py
@@ -1,0 +1,106 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_vedro_allure.config import DefaultConfig
+from flake8_vedro_allure.errors import NoAllureIdError
+from flake8_vedro_allure.visitors import ScenarioVisitor
+from flake8_vedro_allure.visitors.scenario_allure_checkers import (
+    AllureIdRequiredChecker
+)
+
+
+def test_no_allure_id_decorator():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario: pass
+    """
+    assert_error(ScenarioVisitor, code, NoAllureIdError,
+                 config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_no_allure_id_decorator_with_other_decorators():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure_labels(Feature.House)
+    class Scenario: pass
+    """
+    assert_error(ScenarioVisitor, code, NoAllureIdError,
+                 config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_decorator():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure.id(12345)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_and_other_decorators():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure_labels(Feature.House)
+    @allure.id(12345)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_allure_id_not_required():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=False))
+
+
+def test_with_allure_id_method():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        def setup(self):
+            allure.id(12345)
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_dynamic_id_method():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        def setup(self):
+            allure.dynamic.id(12345)
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_in_parameterized_scenario():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        @classmethod
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            
+        def given_parameter(self, param):
+            self.param = param
+            allure.id(f"12345-{param}")
+            
+        def when_action(self):
+            pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True)) 

--- a/tests/test_allure_id_required.py
+++ b/tests/test_allure_id_required.py
@@ -67,7 +67,7 @@ def test_with_allure_id_method():
     ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
     code = """
     class Scenario:
-        def setup(self):
+        def __init__(self):
             allure.id(12345)
     """
     assert_not_error(ScenarioVisitor, code,
@@ -79,8 +79,20 @@ def test_with_allure_dynamic_id_method():
     ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
     code = """
     class Scenario:
-        def setup(self):
+        def __init__(self):
             allure.dynamic.id(12345)
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_allure_id_in_async_method():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    class Scenario:
+        async def setup(self):
+            allure.id(12345)
     """
     assert_not_error(ScenarioVisitor, code,
                      config=DefaultConfig(is_allure_id_required=True))
@@ -91,16 +103,9 @@ def test_with_allure_id_in_parameterized_scenario():
     ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
     code = """
     class Scenario:
-        @classmethod
-        def __init_subclass__(cls, **kwargs):
-            super().__init_subclass__(**kwargs)
-            
-        def given_parameter(self, param):
+        def __init__(self, param):
             self.param = param
             allure.id(f"12345-{param}")
-            
-        def when_action(self):
-            pass
     """
     assert_not_error(ScenarioVisitor, code,
-                     config=DefaultConfig(is_allure_id_required=True)) 
+                     config=DefaultConfig(is_allure_id_required=True))

--- a/tests/test_duplicate_allure_id.py
+++ b/tests/test_duplicate_allure_id.py
@@ -1,0 +1,152 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+from unittest.mock import patch, Mock
+
+from flake8_vedro_allure.config import DefaultConfig
+from flake8_vedro_allure.errors import DuplicateAllureIdError
+from flake8_vedro_allure.visitors import ScenarioVisitor
+from flake8_vedro_allure.visitors.scenario_allure_checkers import (
+    DuplicateAllureIdChecker
+)
+
+
+def test_unique_allure_id():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(DuplicateAllureIdChecker)
+    
+    # Reset allure id cache between tests
+    DuplicateAllureIdChecker.reset_checker()
+    
+    # Create code with two scenarios with different allure.id
+    code = """
+    class Scenario1:
+        def __init__(self):
+            allure.id(12345)
+            
+    class Scenario2:
+        def __init__(self):
+            allure.id(67890)
+    """
+    
+    # Both scenarios should pass the check
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_no_duplicate_with_disabled_check():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(DuplicateAllureIdChecker)
+    
+    # Reset allure id cache between tests
+    DuplicateAllureIdChecker.reset_checker()
+    
+    # Create code with two scenarios with the same allure.id
+    code = """
+    @allure.id(12345)
+    class Scenario1: pass
+    
+    @allure.id(12345)
+    class Scenario2: pass
+    """
+    
+    # If is_allure_id_required=False, the check should not be performed
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=False))
+
+
+def test_duplicate_detection():
+    """
+    Unit test for duplicate detection
+    """
+    # Initialize the checker
+    DuplicateAllureIdChecker.reset_checker()
+    checker = DuplicateAllureIdChecker()
+    
+    with patch.object(checker, 'extract_allure_id', return_value='12345'):
+        class MockNode:
+            def __init__(self, name, lineno=1, col_offset=0):
+                self.name = name
+                self.lineno = lineno
+                self.col_offset = col_offset
+    
+        class MockContext:
+            def __init__(self, filename, scenario_name, lineno=1, col_offset=0):
+                self.filename = filename
+                self.scenario_node = MockNode(scenario_name, lineno, col_offset)
+        
+        # First scenario should be added without errors
+        context1 = MockContext('file1.py', 'Scenario1')
+        errors1 = checker.check_scenario(context1, DefaultConfig(is_allure_id_required=True))
+        assert len(errors1) == 0, "First scenario should not cause an error"
+        
+        # Second scenario with the same ID should cause an error
+        context2 = MockContext('file2.py', 'Scenario2', 10, 5)
+        errors2 = checker.check_scenario(context2, DefaultConfig(is_allure_id_required=True))
+        
+        assert len(errors2) == 1, "Second scenario should cause an error"
+        assert isinstance(errors2[0], DuplicateAllureIdError), "Error should be of type DuplicateAllureIdError"
+
+
+def test_same_filename_different_scenarios():
+    """
+    Test for duplicate detection in the same file with different scenario names
+    """
+    # Initialize the checker
+    DuplicateAllureIdChecker.reset_checker()
+    checker = DuplicateAllureIdChecker()
+    
+    with patch.object(checker, 'extract_allure_id', return_value='12345'):
+        class MockNode:
+            def __init__(self, name, lineno=1, col_offset=0):
+                self.name = name
+                self.lineno = lineno
+                self.col_offset = col_offset
+    
+        class MockContext:
+            def __init__(self, filename, scenario_name, lineno=1, col_offset=0):
+                self.filename = filename
+                self.scenario_node = MockNode(scenario_name, lineno, col_offset)
+        
+        # First scenario in the file
+        context1 = MockContext('file1.py', 'Scenario1')
+        errors1 = checker.check_scenario(context1, DefaultConfig(is_allure_id_required=True))
+        assert len(errors1) == 0, "First scenario should not cause an error"
+        
+        # Second scenario in the same file but with a different name
+        context2 = MockContext('file1.py', 'Scenario2', 10, 5)
+        errors2 = checker.check_scenario(context2, DefaultConfig(is_allure_id_required=True))
+        
+        assert len(errors2) == 1, "Second scenario should cause an error"
+        assert isinstance(errors2[0], DuplicateAllureIdError), "Error should be of type DuplicateAllureIdError"
+
+
+def test_same_class_name_no_error():
+    """
+    Test that identical class names in different files should not cause an error
+    if they have different IDs
+    """
+    # Initialize the checker
+    DuplicateAllureIdChecker.reset_checker()
+    checker = DuplicateAllureIdChecker()
+    
+    class MockNode:
+        def __init__(self, name, lineno=1, col_offset=0):
+            self.name = name
+            self.lineno = lineno
+            self.col_offset = col_offset
+
+    class MockContext:
+        def __init__(self, filename, scenario_name, lineno=1, col_offset=0):
+            self.filename = filename
+            self.scenario_node = MockNode(scenario_name, lineno, col_offset)
+    
+    # Scenario in the first file with ID 12345
+    with patch.object(checker, 'extract_allure_id', return_value='12345'):
+        context1 = MockContext('file1.py', 'Scenario')
+        errors1 = checker.check_scenario(context1, DefaultConfig(is_allure_id_required=True))
+        assert len(errors1) == 0, "First scenario should not cause an error"
+    
+    # Scenario in the second file with the same name but different ID
+    with patch.object(checker, 'extract_allure_id', return_value='67890'):
+        context2 = MockContext('file2.py', 'Scenario', 10, 5)
+        errors2 = checker.check_scenario(context2, DefaultConfig(is_allure_id_required=True))
+        assert len(errors2) == 0, "Second scenario should not cause an error with a different ID" 

--- a/tests/test_duplicate_allure_id.py
+++ b/tests/test_duplicate_allure_id.py
@@ -1,5 +1,5 @@
 from flake8_plugin_utils import assert_error, assert_not_error
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from flake8_vedro_allure.config import DefaultConfig
 from flake8_vedro_allure.errors import DuplicateAllureIdError
@@ -9,125 +9,77 @@ from flake8_vedro_allure.visitors.scenario_allure_checkers import (
 )
 
 
-def test_unique_allure_id():
-    ScenarioVisitor.deregister_all()
-    ScenarioVisitor.register_scenario_checker(DuplicateAllureIdChecker)
-    
-    # Reset allure id cache between tests
-    DuplicateAllureIdChecker.reset_checker()
-    
-    # Create code with two scenarios with different allure.id
-    code = """
-    class Scenario1:
-        def __init__(self):
-            allure.id(12345)
-            
-    class Scenario2:
-        def __init__(self):
-            allure.id(67890)
-    """
-    
-    # Both scenarios should pass the check
-    assert_not_error(ScenarioVisitor, code,
-                     config=DefaultConfig(is_allure_id_required=True))
-
-
 def test_no_duplicate_with_disabled_check():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(DuplicateAllureIdChecker)
-    
-    # Reset allure id cache between tests
-    DuplicateAllureIdChecker.reset_checker()
-    
-    # Create code with two scenarios with the same allure.id
+
     code = """
     @allure.id(12345)
-    class Scenario1: pass
-    
-    @allure.id(12345)
-    class Scenario2: pass
+    class Scenario: pass
     """
-    
-    # If is_allure_id_required=False, the check should not be performed
+
     assert_not_error(ScenarioVisitor, code,
                      config=DefaultConfig(is_allure_id_required=False))
 
 
 def test_duplicate_detection():
-    """
-    Unit test for duplicate detection
-    """
-    # Initialize the checker
-    DuplicateAllureIdChecker.reset_checker()
     checker = DuplicateAllureIdChecker()
-    
+    checker.reset_checker()
+
     with patch.object(checker, 'extract_allure_id', return_value='12345'):
         class MockNode:
             def __init__(self, name, lineno=1, col_offset=0):
                 self.name = name
                 self.lineno = lineno
                 self.col_offset = col_offset
-    
+
         class MockContext:
-            def __init__(self, filename, scenario_name, lineno=1, col_offset=0):
+            def __init__(self, filename, lineno=1, col_offset=0):
                 self.filename = filename
-                self.scenario_node = MockNode(scenario_name, lineno, col_offset)
-        
-        # First scenario should be added without errors
-        context1 = MockContext('file1.py', 'Scenario1')
+                self.scenario_node = MockNode('Scenario', lineno, col_offset)
+                self.import_from_nodes = []
+
+        context1 = MockContext('file1.py')
         errors1 = checker.check_scenario(context1, DefaultConfig(is_allure_id_required=True))
         assert len(errors1) == 0, "First scenario should not cause an error"
-        
-        # Second scenario with the same ID should cause an error
-        context2 = MockContext('file2.py', 'Scenario2', 10, 5)
+
+        context2 = MockContext('file2.py', 10, 5)
         errors2 = checker.check_scenario(context2, DefaultConfig(is_allure_id_required=True))
-        
+
         assert len(errors2) == 1, "Second scenario should cause an error"
-        assert isinstance(errors2[0], DuplicateAllureIdError), "Error should be of type DuplicateAllureIdError"
+        assert isinstance(errors2[0], DuplicateAllureIdError)
 
 
-def test_same_filename_different_scenarios():
-    """
-    Test for duplicate detection in the same file with different scenario names
-    """
-    # Initialize the checker
-    DuplicateAllureIdChecker.reset_checker()
+def test_same_file_no_error():
     checker = DuplicateAllureIdChecker()
-    
+    checker.reset_checker()
+
     with patch.object(checker, 'extract_allure_id', return_value='12345'):
         class MockNode:
             def __init__(self, name, lineno=1, col_offset=0):
                 self.name = name
                 self.lineno = lineno
                 self.col_offset = col_offset
-    
+
         class MockContext:
-            def __init__(self, filename, scenario_name, lineno=1, col_offset=0):
+            def __init__(self, filename, lineno=1, col_offset=0):
                 self.filename = filename
-                self.scenario_node = MockNode(scenario_name, lineno, col_offset)
-        
-        # First scenario in the file
-        context1 = MockContext('file1.py', 'Scenario1')
+                self.scenario_node = MockNode('Scenario', lineno, col_offset)
+                self.import_from_nodes = []
+
+        context1 = MockContext('file1.py')
         errors1 = checker.check_scenario(context1, DefaultConfig(is_allure_id_required=True))
-        assert len(errors1) == 0, "First scenario should not cause an error"
-        
-        # Second scenario in the same file but with a different name
-        context2 = MockContext('file1.py', 'Scenario2', 10, 5)
+        assert len(errors1) == 0
+
+        context2 = MockContext('file1.py', 10, 5)
         errors2 = checker.check_scenario(context2, DefaultConfig(is_allure_id_required=True))
-        
-        assert len(errors2) == 1, "Second scenario should cause an error"
-        assert isinstance(errors2[0], DuplicateAllureIdError), "Error should be of type DuplicateAllureIdError"
+        assert len(errors2) == 0, "Same file should not cause a duplicate error"
 
 
-def test_same_class_name_no_error():
-    """
-    Test that identical class names in different files should not cause an error
-    if they have different IDs
-    """
-    # Initialize the checker
-    DuplicateAllureIdChecker.reset_checker()
+def test_different_ids_no_error():
     checker = DuplicateAllureIdChecker()
-    
+    checker.reset_checker()
+
     class MockNode:
         def __init__(self, name, lineno=1, col_offset=0):
             self.name = name
@@ -135,18 +87,30 @@ def test_same_class_name_no_error():
             self.col_offset = col_offset
 
     class MockContext:
-        def __init__(self, filename, scenario_name, lineno=1, col_offset=0):
+        def __init__(self, filename, lineno=1, col_offset=0):
             self.filename = filename
-            self.scenario_node = MockNode(scenario_name, lineno, col_offset)
-    
-    # Scenario in the first file with ID 12345
+            self.scenario_node = MockNode('Scenario', lineno, col_offset)
+            self.import_from_nodes = []
+
     with patch.object(checker, 'extract_allure_id', return_value='12345'):
-        context1 = MockContext('file1.py', 'Scenario')
+        context1 = MockContext('file1.py')
         errors1 = checker.check_scenario(context1, DefaultConfig(is_allure_id_required=True))
-        assert len(errors1) == 0, "First scenario should not cause an error"
-    
-    # Scenario in the second file with the same name but different ID
+        assert len(errors1) == 0
+
     with patch.object(checker, 'extract_allure_id', return_value='67890'):
-        context2 = MockContext('file2.py', 'Scenario', 10, 5)
+        context2 = MockContext('file2.py', 10, 5)
         errors2 = checker.check_scenario(context2, DefaultConfig(is_allure_id_required=True))
-        assert len(errors2) == 0, "Second scenario should not cause an error with a different ID" 
+        assert len(errors2) == 0, "Different IDs should not cause an error"
+
+
+def test_allure_id_keyword_arg():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(DuplicateAllureIdChecker)
+
+    code = """
+    @allure.id(id=12345)
+    class Scenario: pass
+    """
+
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))

--- a/tests/test_id_decorator.py
+++ b/tests/test_id_decorator.py
@@ -1,0 +1,42 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+
+from flake8_vedro_allure.config import DefaultConfig
+from flake8_vedro_allure.errors import NoAllureIdError
+from flake8_vedro_allure.visitors import ScenarioVisitor
+from flake8_vedro_allure.visitors.scenario_allure_checkers import (
+    AllureIdRequiredChecker
+)
+
+
+def test_with_simple_id_decorator():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @id(123)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_simple_id_decorator_and_other_decorators():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @allure_labels(Feature.House)
+    @id(123)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_simple_id_decorator_when_not_required():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+    @id(123)
+    class Scenario: pass
+    """
+    assert_not_error(ScenarioVisitor, code,
+                     config=DefaultConfig(is_allure_id_required=False)) 

--- a/tests/test_id_decorator.py
+++ b/tests/test_id_decorator.py
@@ -8,35 +8,52 @@ from flake8_vedro_allure.visitors.scenario_allure_checkers import (
 )
 
 
-def test_with_simple_id_decorator():
+def test_with_id_from_allure_import():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
     code = """
-    @id(123)
-    class Scenario: pass
+from allure import id
+
+@id(123)
+class Scenario: pass
     """
     assert_not_error(ScenarioVisitor, code,
                      config=DefaultConfig(is_allure_id_required=True))
 
 
-def test_with_simple_id_decorator_and_other_decorators():
+def test_with_id_from_allure_import_and_other_decorators():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
     code = """
-    @allure_labels(Feature.House)
-    @id(123)
-    class Scenario: pass
+from allure import id
+
+@allure_labels(Feature.House)
+@id(123)
+class Scenario: pass
     """
     assert_not_error(ScenarioVisitor, code,
                      config=DefaultConfig(is_allure_id_required=True))
 
 
-def test_with_simple_id_decorator_when_not_required():
+def test_with_id_from_non_allure_import():
     ScenarioVisitor.deregister_all()
     ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
     code = """
-    @id(123)
-    class Scenario: pass
+from any_other_lib import id
+
+@id(1)
+class Scenario: pass
     """
-    assert_not_error(ScenarioVisitor, code,
-                     config=DefaultConfig(is_allure_id_required=False)) 
+    assert_error(ScenarioVisitor, code, NoAllureIdError,
+                 config=DefaultConfig(is_allure_id_required=True))
+
+
+def test_with_id_without_import():
+    ScenarioVisitor.deregister_all()
+    ScenarioVisitor.register_scenario_checker(AllureIdRequiredChecker)
+    code = """
+@id(123)
+class Scenario: pass
+    """
+    assert_error(ScenarioVisitor, code, NoAllureIdError,
+                 config=DefaultConfig(is_allure_id_required=True))


### PR DESCRIPTION
…… (#1)

* Enhance flake8-vedro-allure with allure.id() requirement and testing setup

- Added a new rule (ALR004) to enforce the use of @allure.id() decorator for scenarios.
- Updated configuration to include is_allure_id_required option.
- Introduced NoAllureIdError for scenarios lacking the @allure.id() decorator.
- Enhanced README with details about the new rule and its usage.
- Added test targets in Makefile and GitHub Actions workflow for automated testing.


---------